### PR TITLE
Node 8 requires [''] instead of . syntax

### DIFF
--- a/16_recursion/solution.js
+++ b/16_recursion/solution.js
@@ -1,6 +1,6 @@
 function getDependencies(mod, result) {
   result = result || []
-  var dependencies = mod.dependencies || []
+  var dependencies = mod['dependencies'] || []
   Object.keys(dependencies).forEach(function(dep) {
     var key = dep + '@' + mod.dependencies[dep].version
     if (result.indexOf(key) === -1) result.push(key)


### PR DESCRIPTION
Node 8 requires [''] instead of . syntax to work.